### PR TITLE
Corrige a sobreposição de elementos no status do usuário

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8 relative overflow-x-hidden">
 
     <!-- Status do Usuário -->
-    <div id="user-status" class="absolute top-4 right-4 md:top-6 md:right-6 text-right hidden z-10 flex items-center gap-3">
-        <p id="user-name" class="text-sm md:text-base"></p>
+    <div id="user-status" class="absolute top-4 right-4 md:top-6 md:right-6 hidden z-10 flex items-center gap-3">
+        <p id="user-name" class="text-sm md:text-base truncate max-w-[100px] md:max-w-xs"></p>
         <button id="gallery-button" title="Ver filmes assistidos">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-500 hover:text-amber-400 transition-colors"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
         </button>


### PR DESCRIPTION
Impede que o nome do usuário, o ícone de galeria e o botão de sair se sobreponham em telas pequenas.

A solução aplica um `max-width` e a classe `truncate` ao nome do usuário. Isso garante que o texto seja elegantemente cortado com um '...' quando exceder o espaço disponível, mantendo todos os elementos em uma única linha limpa e funcional, sem quebrar o layout.